### PR TITLE
adding a test cookbook so we can test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,9 +8,10 @@ provisioner:
 
 platforms:
   - name: centos-6.8
+  - name: centos-7
 
 suites:
   - name: default
     run_list:
-      - recipe[cspp::default]
+      - recipe[cspp-test::default]
     attributes:

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source "https://supermarket.chef.io"
 
 metadata
+
+cookbook 'cspp-test', path: 'test/cookbooks/cspp-test'

--- a/test/cookbooks/cspp-test/README.md
+++ b/test/cookbooks/cspp-test/README.md
@@ -1,0 +1,1 @@
+This is a test cookbook

--- a/test/cookbooks/cspp-test/metadata.rb
+++ b/test/cookbooks/cspp-test/metadata.rb
@@ -1,0 +1,4 @@
+name 'cspp-test'
+version '0.0.1'
+
+depends 'cspp'

--- a/test/cookbooks/cspp-test/recipes/default.rb
+++ b/test/cookbooks/cspp-test/recipes/default.rb
@@ -1,0 +1,17 @@
+user 'processing'
+group 'processing'
+
+cspp_package 'SDR' do
+  source 'https://s3-us-west-2.amazonaws.com/gina-packages/SSEC/CSPP'
+  version "3.0"
+  patch "3.0.3"
+end
+
+cspp_ancillary_package 'SDR' do
+  source 'https://s3-us-west-2.amazonaws.com/gina-packages/SSEC/CSPP'
+  version "3.0"
+  ancillary ["CACHE", "STATIC"]
+  user 'processing'
+  group 'processing'
+end
+


### PR DESCRIPTION
How better to know if we've got ability to install 3.0 and patch it with 3.0.3 than a test that does exactly that!

This here is an upgrade to add a test cookbook to let us verify we've actually uploaded and named CSPP stuff in `gina-packages/SSEC/CSPP` in a correct enough way that our installer can find and install it.